### PR TITLE
Add theming to the app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import {Moon, Sun} from 'lucide-react-native';
+import {Haptics} from 'react-native-nitro-haptics';
 
 const App = () => {
   const opacity = useSharedValue(0);
@@ -35,6 +36,11 @@ const App = () => {
 
   const AnimatedText = Animated.createAnimatedComponent(Text);
 
+  const toggleThemeHandler = () => {
+    Haptics.impact('heavy');
+    toggleTheme();
+  };
+
   return (
     <View
       style={[
@@ -55,20 +61,12 @@ const App = () => {
       </AnimatedText>
 
       <TouchableOpacity
-        onPress={toggleTheme}
-        style={{
-          position: 'absolute',
-          top: 15,
-          right: 15,
-          width: 40,
-          height: 40,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}>
+        onPress={toggleThemeHandler}
+        style={styles.buttonContainer}>
         {!isDarkMode ? (
           <Moon size={30} color={'black'} />
         ) : (
-          <Sun size={30} color={'white'} />
+          <Sun size={30} color={'black'} />
         )}
       </TouchableOpacity>
     </View>
@@ -89,6 +87,17 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#aaa',
     marginTop: 8,
+  },
+  buttonContainer: {
+    position: 'absolute',
+    bottom: 30,
+    right: 30,
+    width: 50,
+    height: 50,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ddd',
+    borderRadius: 10,
   },
 });
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,15 +1,18 @@
+import {useTheme} from '@/hooks/useTheme';
 import React, {useEffect} from 'react';
-import {View, Text, StyleSheet} from 'react-native';
+import {View, Text, StyleSheet, Switch, TouchableOpacity} from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
   Easing,
 } from 'react-native-reanimated';
+import {Moon, Sun} from 'lucide-react-native';
 
 const App = () => {
   const opacity = useSharedValue(0);
   const scale = useSharedValue(10); // start far away (big scale)
+  const {toggleTheme, isDarkMode} = useTheme();
 
   useEffect(() => {
     opacity.value = withTiming(1, {
@@ -33,13 +36,41 @@ const App = () => {
   const AnimatedText = Animated.createAnimatedComponent(Text);
 
   return (
-    <View style={styles.container}>
-      <AnimatedText style={[styles.title, animatedStyle]}>
+    <View
+      style={[
+        styles.container,
+        {backgroundColor: isDarkMode ? 'black' : 'white'},
+      ]}>
+      <AnimatedText
+        style={[
+          styles.title,
+          animatedStyle,
+          {color: isDarkMode ? 'white' : 'black'},
+        ]}
+        onPress={toggleTheme}>
         This is Uganda
       </AnimatedText>
       <AnimatedText style={[styles.subtitle, animatedStyle]}>
         Coming soon...
       </AnimatedText>
+
+      <TouchableOpacity
+        onPress={toggleTheme}
+        style={{
+          position: 'absolute',
+          top: 15,
+          right: 15,
+          width: 40,
+          height: 40,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+        {!isDarkMode ? (
+          <Moon size={30} color={'black'} />
+        ) : (
+          <Sun size={30} color={'white'} />
+        )}
+      </TouchableOpacity>
     </View>
   );
 };
@@ -51,7 +82,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   title: {
-    fontSize: 20,
+    fontSize: 30,
     fontWeight: '600',
   },
   subtitle: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,15 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['./src'],
+        alias: {
+          '@': './src',
+        },
+      },
+    ],
     // Everyhting should be above this.
     'react-native-reanimated/plugin',
   ],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -25,6 +25,53 @@ PODS:
   - libwebp/sharpyuv (1.5.0)
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
+  - NitroHaptics (0.1.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - NitroModules
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - NitroModules (0.25.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1779,7 +1826,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (4.0.0-beta.3):
+  - RNReanimated (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1801,10 +1848,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.0.0-beta.3)
-    - RNWorklets
+    - RNReanimated/reanimated (= 3.17.5)
+    - RNReanimated/worklets (= 3.17.5)
     - Yoga
-  - RNReanimated/reanimated (4.0.0-beta.3):
+  - RNReanimated/reanimated (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1826,10 +1873,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.0.0-beta.3)
-    - RNWorklets
+    - RNReanimated/reanimated/apple (= 3.17.5)
     - Yoga
-  - RNReanimated/reanimated/apple (4.0.0-beta.3):
+  - RNReanimated/reanimated/apple (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1851,7 +1897,53 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets
+    - Yoga
+  - RNReanimated/worklets (3.17.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/worklets/apple (= 3.17.5)
+    - Yoga
+  - RNReanimated/worklets/apple (3.17.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - Yoga
   - RNScreens (4.10.0):
     - DoubleConversion
@@ -1941,71 +2033,6 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNWorklets (0.1.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.1.0)
-    - Yoga
-  - RNWorklets/worklets (0.1.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.1.0)
-    - Yoga
-  - RNWorklets/worklets/apple (0.1.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - SDWebImage (5.20.1):
     - SDWebImage/Core (= 5.20.1)
   - SDWebImage/Core (5.20.1)
@@ -2027,6 +2054,8 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - NitroHaptics (from `../node_modules/react-native-nitro-haptics`)
+  - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2100,7 +2129,6 @@ DEPENDENCIES:
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - RNWorklets (from `../node_modules/react-native-worklets`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2130,6 +2158,10 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2024-11-25-RNv0.77.0-d4f25d534ab744866448b36ca3bf3d97c08e638c
+  NitroHaptics:
+    :path: "../node_modules/react-native-nitro-haptics"
+  NitroModules:
+    :path: "../node_modules/react-native-nitro-modules"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2272,8 +2304,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
-  RNWorklets:
-    :path: "../node_modules/react-native-worklets"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -2288,6 +2318,8 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
+  NitroHaptics: 55ce0d5a762f267599ce5b4b4a374fb6e1800817
+  NitroModules: 6cad985fa4a6efaf567fe5c9aa464bce17e2d0cc
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: f5c19ebdb8804b53ed029123eb69914356192fc8
   RCTRequired: 6ae6cebe470486e0e0ce89c1c0eabb998e7c51f4
@@ -2356,10 +2388,9 @@ SPEC CHECKSUMS:
   ReactNativeFs: 6f1bd892fbb640aa023974033b92ed683199704b
   RNFastImage: a28d24ed0a1e9807da556efef0630b71c1a9a78a
   RNGestureHandler: 66e593addd8952725107cfaa4f5e3378e946b541
-  RNReanimated: 91b22c70b3872a45bfe508878c60acfd4c5491c8
+  RNReanimated: a1f7ece8b19bffad90fa3de403ef01a9ebc9f5da
   RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   RNSVG: cb725f4400af94396beaeab55098e0a57f2ee020
-  RNWorklets: ed46246d1064c3b5e39093ab46cf4ccbbc8e9152
   SDWebImage: 33d0f23bddeb5d209ae959153883247be6703713
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
+    "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "react-native-compressor": "^1.11.0",
     "react-native-gesture-handler": "^2.25.0",
     "react-native-mmkv": "^3.2.0",
+    "react-native-nitro-haptics": "^0.1.0",
+    "react-native-nitro-modules": "^0.25.2",
     "react-native-ota-hot-update": "^2.2.9",
     "react-native-reanimated": "^3.17.5",
     "react-native-safe-area-context": "^5.4.0",

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,66 @@
+// src/hooks/useTheme.ts
+import {Appearance} from 'react-native';
+import {signal, computed, useSignal} from '@preact/signals-react';
+import {useSignals} from '@preact/signals-react/runtime';
+import {themePreference} from '@/signals/theme';
+import {ThemePreference, UseThemeReturn} from '@/types/theme';
+
+// 2. Signal to track system color scheme
+const systemTheme = signal<'light' | 'dark'>(
+  Appearance.getColorScheme() === 'dark' ? 'dark' : 'light',
+);
+
+// 3. Listen to system changes
+Appearance.addChangeListener(({colorScheme}) => {
+  if (colorScheme) {
+    systemTheme.value = colorScheme === 'dark' ? 'dark' : 'light';
+  }
+});
+
+// 4. Compute the effective theme
+const effectiveTheme = computed(() =>
+  themePreference.value === 'system'
+    ? systemTheme.value
+    : themePreference.value,
+);
+
+const isDarkMode = computed(() => effectiveTheme.value === 'dark');
+
+// 5. Hook
+export const useTheme = (): UseThemeReturn => {
+  useSignals();
+  useSignal(themePreference);
+  useSignal(effectiveTheme);
+
+  /**
+   * Sets the user's theme preference.
+   * Use `'light'`, `'dark'`, or `'system'`.
+   */
+  const setThemePreference = (pref: ThemePreference) => {
+    themePreference.value = pref;
+  };
+
+  /**
+   * Toggles between light and dark theme.
+   * If current theme is dark, switches to light, and vice versa.
+   * Does not toggle to/from system mode.
+   */
+  const toggleTheme = () => {
+    const current = effectiveTheme.value;
+    themePreference.value = current === 'dark' ? 'light' : 'dark';
+  };
+
+  return {
+    /** Whether the effective theme is dark mode */
+    isDarkMode: isDarkMode.value,
+
+    /** The user's selected preference: 'light', 'dark', or 'system' */
+    preference: themePreference.value,
+
+    /** Whether the app is following the system theme */
+    isUsingSystem: themePreference.value === 'system',
+
+    setThemePreference,
+    toggleTheme,
+  };
+};

--- a/src/signals/theme.ts
+++ b/src/signals/theme.ts
@@ -1,0 +1,4 @@
+import {ThemePreference} from '@/types/theme';
+import {signal} from '@preact/signals-react';
+
+export const themePreference = signal<ThemePreference>('system');

--- a/src/signals/theme.ts
+++ b/src/signals/theme.ts
@@ -1,4 +1,7 @@
 import {ThemePreference} from '@/types/theme';
 import {signal} from '@preact/signals-react';
 
+/**
+ * Signal representing the user's preferred theme.
+ */
 export const themePreference = signal<ThemePreference>('system');

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,0 +1,20 @@
+// src/types/theme.d.ts
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+export type UseThemeReturn = {
+  /** Whether the effective theme is dark mode */
+  isDarkMode: boolean;
+
+  /** The user's selected preference: 'light', 'dark', or 'system' */
+  preference: ThemePreference;
+
+  /** Whether the app is following the system theme */
+  isUsingSystem: boolean;
+
+  /** Set the user's theme preference */
+  setThemePreference: (pref: ThemePreference) => void;
+
+  /** Toggle between light and dark mode */
+  toggleTheme: () => void;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "@react-native/typescript-config/tsconfig.json"
+  "extends": "@react-native/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,17 @@ babel-plugin-jest-hoist@^29.6.3:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz#cdeac5d4aaa3b08dd1ac23ddbf516660ed2d293e"
+  integrity sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==
+  dependencies:
+    find-babel-config "^2.1.1"
+    glob "^9.3.3"
+    pkg-up "^3.1.0"
+    reselect "^4.1.7"
+    resolve "^1.22.8"
+
 babel-plugin-polyfill-corejs2@^0.4.10:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz#7d445f0e0607ebc8fb6b01d7e8fb02069b91dd8b"
@@ -4026,6 +4037,13 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-2.1.2.tgz#2841b1bfbbbcdb971e1e39df8cbc43dafa901716"
+  integrity sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==
+  dependencies:
+    json5 "^2.2.3"
+
 find-cache-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -4233,6 +4251,16 @@ glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^9.3.3:
+  version "9.3.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.5.tgz#ca2ed8ca452781a3009685607fdf025a899dfe21"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -5704,6 +5732,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^8.0.2:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
+  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
@@ -5722,6 +5757,11 @@ minimisted@^2.0.0:
   integrity sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==
   dependencies:
     minimist "^1.2.5"
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
@@ -6075,7 +6115,7 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.11.1:
+path-scurry@^1.11.1, path-scurry@^1.6.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
@@ -6121,6 +6161,13 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
 
 plist@^3.1.0:
   version "3.1.0"
@@ -6534,6 +6581,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+reselect@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -6561,7 +6613,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.14.2, resolve@^1.20.0:
+resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.8:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6340,6 +6340,16 @@ react-native-mmkv@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-3.2.0.tgz#460723eb23b9cc92c65b0416eae9874a6ddf5b82"
   integrity sha512-9y7K//1MaU46TFrXkyU0wT5VGk9Y2FDLFV6NPl+z3jTbm2G7SC1UIxneF6CfhSmBX5CfKze9SO7kwDuRx7flpQ==
 
+react-native-nitro-haptics@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-haptics/-/react-native-nitro-haptics-0.1.0.tgz#1fc315814fbace0a9fc24a7468b262512fd66d59"
+  integrity sha512-oEXjK7FHz7TU9d83pTLXtDqHJNQbeKmy9UDBPK6o1tChkKjjM2w1lp/bdqOwHPvh/+a2sZH3ILTnCT2Pi0sAew==
+
+react-native-nitro-modules@^0.25.2:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.25.2.tgz#3d03869934854d7509c2f0dbaf4dca83d6969faf"
+  integrity sha512-rL+X0LzB8BXvpdrUE/+oZ5v4qS/1nZIq0M8Uctbvqq2q53sVCHX4995ffT8+lGIJe/f0QcBvvrEeXtBPl86iwQ==
+
 react-native-ota-hot-update@^2.2.9:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/react-native-ota-hot-update/-/react-native-ota-hot-update-2.2.9.tgz#469aeaac7f01812e03f09506a464f6588ebe8a5b"


### PR DESCRIPTION
### 📌 Summary

This PR introduces a flexible theming system to the app, allowing users to switch between light, dark, and system themes. It leverages `@preact/signals-react` for reactive theme state management and integrates with the native `Appearance` API to respect system settings.


### ✅ What’s Included

* `useTheme` hook:

* Returns `isDarkMode`, `preference`, `isUsingSystem`
* Includes `setThemePreference` and `toggleTheme` functions
* Reactivity handled via `useSignals()`
* Signals-based theme state (no context API needed)
* Appearance listener for system theme changes
* Type definitions extracted to `types/theme.d.ts`
* Support for alias imports using `@/` (e.g., `@/hooks/useTheme`)


### 🧪 How to Test

1. Call `useTheme()` in any component
2. Test theme toggling and switching to system mode
3. Validate reactivity on theme changes (UI should update automatically)
4. To test this in action use the toggle button on the home screen in the top right corner to toggle between dark and light modes

### 📁 Future Work (Not in This PR)

* Apply actual theme styles to UI components
* Persist theme preference using `MMKV`
* Optional dark/light theme object implementation
